### PR TITLE
Fix store_name format not matching core behaviour

### DIFF
--- a/app/code/community/Idealo/Direktkauf/Model/Cronjobs/Base.php
+++ b/app/code/community/Idealo/Direktkauf/Model/Cronjobs/Base.php
@@ -94,7 +94,9 @@ class Idealo_Direktkauf_Model_Cronjobs_Base
      */
     protected function _getStoreName()
     {
-        return $this->_getStore()->getFrontendName().' - '.$this->_getStore()->getName();
+        $store = $this->_getStore();
+        $name = array($store->getWebsite()->getName(), $store->getGroup()->getName(), $store->getName());
+        return implode("\n", $name);
     }
     
     /**


### PR DESCRIPTION
Currently the generated `store_name` for imported orders doesn't have the same format as Magento generated orders.