### PR TITLE
Fix empty check in _insertRecord

### DIFF
--- a/app/code/community/Idealo/Direktkauf/Model/Cronjobs/Base.php
+++ b/app/code/community/Idealo/Direktkauf/Model/Cronjobs/Base.php
@@ -170,7 +170,7 @@ class Idealo_Direktkauf_Model_Cronjobs_Base
     protected function _insertRecord($aData, $sTableModel)
     {
         $sTable = $this->_getTableName($sTableModel);
-        if ($sTable && is_array($aData) && !empty($aData) > 0) {
+        if ($sTable && is_array($aData) && !empty($aData)) {
             $aData = $this->_checkData($aData, $sTable);
             
             $aFields = array_keys($aData);


### PR DESCRIPTION
Probably a `count()` that got refactored to use `empty()` instead.